### PR TITLE
Feature/members my page : Feat - 마이페이지 관련 API 구현 및 mockuser를 이용한 테스트코드 작성

### DIFF
--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/config/SecurityConfig.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/config/SecurityConfig.kt
@@ -33,6 +33,10 @@ class SecurityConfig {
             .failureUrl("/")
             .and()
             .logout()
+            .logoutUrl("/members/logout") // 로그아웃 처리 URL
+            .logoutSuccessUrl("/login") // 로그아웃 성공 후 이동페이지
+            .invalidateHttpSession(true)
+            .deleteCookies("JSESSIONID")
             .and()
             .build()
     }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/config/SecurityConfig.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/config/SecurityConfig.kt
@@ -20,6 +20,7 @@ class SecurityConfig {
     @Bean
     fun defaultSecurityFilterChain(http:HttpSecurity): SecurityFilterChain{
         http.csrf().disable()//post 요청 허용
+        http.httpBasic() //postman 테스트를 위해 설정
         return http.authorizeRequests()
             //.antMatchers("/user/**").authenticated()
             .antMatchers("/admins/**").hasRole("ADMIN")

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
@@ -44,4 +44,9 @@ class MemberController(private val memberService: MemberService) {
     fun updateMyPageInfo(@AuthenticationPrincipal authMemberDTO: AuthMemberDTO?, @RequestBody requestUpdateMyPageDTO:RequestUpdateMyPageDTO):ResponseEntity<ResponseDTO>{
         return memberService.updateMyPageInfo(authMemberDTO?.memberId,requestUpdateMyPageDTO)
     }
+
+    @PutMapping("/password")
+    fun updatePassword(@AuthenticationPrincipal authMemberDTO: AuthMemberDTO?,@RequestBody requestUpdatePasswordDTO: RequestUpdatePasswordDTO):ResponseEntity<ResponseDTO>{
+        return memberService.updatePassword(authMemberDTO?.memberId,requestUpdatePasswordDTO)
+    }
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
@@ -39,4 +39,9 @@ class MemberController(private val memberService: MemberService) {
     fun getMyPageInfo(@AuthenticationPrincipal authMemberDTO: AuthMemberDTO?): ResponseMyPageDTO {
         return memberService.getMyPageInfo(authMemberDTO?.memberId)
     }
+
+    @PutMapping("")
+    fun updateMyPageInfo(@AuthenticationPrincipal authMemberDTO: AuthMemberDTO?, @RequestBody requestUpdateMyPageDTO:RequestUpdateMyPageDTO):ResponseEntity<ResponseDTO>{
+        return memberService.updateMyPageInfo(authMemberDTO?.memberId,requestUpdateMyPageDTO)
+    }
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
@@ -1,17 +1,16 @@
 package com.lionTF.CShop.domain.member.controller
 
 
-import com.lionTF.CShop.domain.member.controller.dto.RequestIdInquiryDTO
-import com.lionTF.CShop.domain.member.controller.dto.RequestPasswordInquiryDTO
-import com.lionTF.CShop.domain.member.controller.dto.RequestSignUpDTO
-import com.lionTF.CShop.domain.member.controller.dto.ResponseDTO
+import com.lionTF.CShop.domain.member.controller.dto.*
 import com.lionTF.CShop.domain.member.service.MemberService
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
 
 
-@Controller
+@RestController
 @RequestMapping("/members")
 class MemberController(private val memberService: MemberService) {
 
@@ -35,5 +34,9 @@ class MemberController(private val memberService: MemberService) {
     fun passwordInquiry(@RequestBody requestPasswordInquiryDTO: RequestPasswordInquiryDTO):ResponseEntity<ResponseDTO>{
         return memberService.passwordInquiry(requestPasswordInquiryDTO)
     }
-
+    //마이페이지
+    @GetMapping("")
+    fun getMyPageInfo(@AuthenticationPrincipal authMemberDTO: AuthMemberDTO?): ResponseMyPageDTO {
+        return memberService.getMyPageInfo(authMemberDTO?.memberId)
+    }
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MyPageDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MyPageDTO.kt
@@ -27,5 +27,7 @@ data class ResponseMyPageDTO(val status:Int,
 
 }
 
+data class RequestUpdateMyPageDTO(val id:String,val address: String)
+
 data class MyPageResultDTO(val id:String,val phoneNumber: String,val memberName:String,val address:String)
 

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MyPageDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MyPageDTO.kt
@@ -1,0 +1,31 @@
+package com.lionTF.CShop.domain.member.controller.dto
+
+import com.lionTF.CShop.domain.member.models.Member
+import org.springframework.http.HttpStatus
+
+data class ResponseMyPageDTO(val status:Int,
+                             val message:String,
+                             val result:MyPageResultDTO,
+){
+
+    companion object{
+        fun memberToResponseMyPageDTO(member:Member): ResponseMyPageDTO {
+            val myPageResultDTO=MyPageResultDTO(
+                member.id,
+                member.phoneNumber,
+                member.memberName,
+                member.address
+            )
+
+            return ResponseMyPageDTO(
+                HttpStatus.OK.value(),
+                message="마이페이지 조회를 성공했습니다.",
+                myPageResultDTO
+            )
+        }
+    }
+
+}
+
+data class MyPageResultDTO(val id:String,val phoneNumber: String,val memberName:String,val address:String)
+

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MyPageDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MyPageDTO.kt
@@ -31,3 +31,4 @@ data class RequestUpdateMyPageDTO(val id:String,val address: String)
 
 data class MyPageResultDTO(val id:String,val phoneNumber: String,val memberName:String,val address:String)
 
+data class RequestUpdatePasswordDTO(val pastPassword:String,val newPassword:String)

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/RequestSignUpDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/RequestSignUpDTO.kt
@@ -11,7 +11,7 @@ data class RequestSignUpDTO(val id:String,
                             val address:String,){
 
 
-        val passwordEncoder: PasswordEncoder=BCryptPasswordEncoder()
+        private val passwordEncoder: PasswordEncoder=BCryptPasswordEncoder()
 
         init {
             password=passwordEncoder.encode(password)

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/models/Member.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/models/Member.kt
@@ -1,6 +1,8 @@
 package com.lionTF.CShop.domain.member.models
 
+import com.lionTF.CShop.domain.member.controller.dto.MyPageResultDTO
 import com.lionTF.CShop.domain.member.controller.dto.RequestSignUpDTO
+import com.lionTF.CShop.domain.member.controller.dto.RequestUpdateMyPageDTO
 import com.lionTF.CShop.domain.shop.models.Cart
 import com.lionTF.CShop.domain.shop.models.Orders
 import com.lionTF.CShop.global.model.BaseTimeEntity
@@ -40,11 +42,16 @@ class Member(
                 phoneNumber=requestSignUpDTO.phoneNumber,
                 memberName=requestSignUpDTO.memberName,
                 address=requestSignUpDTO.address,
-                cart=Cart()
+                cart=Cart(),
+                role = MemberRole.MEMBER
             )
         }
     }
 
+    fun updateMember(requestUpdateMyPageDTO: RequestUpdateMyPageDTO){
+        this.id=requestUpdateMyPageDTO.id
+        this.address=requestUpdateMyPageDTO.address
+    }
     fun deleteMember(){
         memberStatus = false
     }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/models/Member.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/models/Member.kt
@@ -7,6 +7,7 @@ import com.lionTF.CShop.domain.shop.models.Cart
 import com.lionTF.CShop.domain.shop.models.Orders
 import com.lionTF.CShop.global.model.BaseTimeEntity
 import lombok.*
+import org.springframework.security.crypto.password.PasswordEncoder
 import javax.persistence.*
 
 @Entity
@@ -51,6 +52,10 @@ class Member(
     fun updateMember(requestUpdateMyPageDTO: RequestUpdateMyPageDTO){
         this.id=requestUpdateMyPageDTO.id
         this.address=requestUpdateMyPageDTO.address
+    }
+
+    fun updateMemberPassword(newPassword:String,passwordEncoder:PasswordEncoder){
+        this.password=passwordEncoder.encode(newPassword)
     }
     fun deleteMember(){
         memberStatus = false

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
@@ -10,6 +10,8 @@ interface MemberAuthRepository:JpaRepository<Member,Long> {
 
     @Query("select m from Member m where m.id = :id")
     fun findById(@Param("id")id:String):Optional<Member>
+
     fun findByIdAndPhoneNumber(id:String,phoneNumber: String):Optional<Member>
     fun findByMemberNameAndPhoneNumber(memberName:String,phoneNumber:String):Optional<Member>
+    fun findByMemberId(memberId:Long?):Optional<Member>
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
@@ -10,6 +10,6 @@ interface MemberAuthRepository:JpaRepository<Member,Long> {
 
     @Query("select m from Member m where m.id = :id")
     fun findById(@Param("id")id:String):Optional<Member>
-
+    fun findByIdAndPhoneNumber(id:String,phoneNumber: String):Optional<Member>
     fun findByMemberNameAndPhoneNumber(memberName:String,phoneNumber:String):Optional<Member>
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
@@ -10,7 +10,6 @@ interface MemberAuthRepository:JpaRepository<Member,Long> {
 
     @Query("select m from Member m where m.id = :id")
     fun findById(@Param("id")id:String):Optional<Member>
-
     fun findByIdAndPhoneNumber(id:String,phoneNumber: String):Optional<Member>
     fun findByMemberNameAndPhoneNumber(memberName:String,phoneNumber:String):Optional<Member>
     fun findByMemberId(memberId:Long?):Optional<Member>

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
@@ -131,7 +131,7 @@ class MemberService(val memberAuthRepository: MemberAuthRepository,val cartRepos
 
         when(canUpdate){
             true->{
-                existMember.password=passwordEncoder.encode(newPassword)
+                existMember.updateMemberPassword(newPassword,passwordEncoder)
                 memberAuthRepository.save(existMember)
                 status=HttpStatus.CREATED
                 responseDTO= ResponseDTO(status.value(),"비밀번호가 성공적으로 수정되었습니다.")

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
@@ -63,7 +63,7 @@ class MemberService(val memberAuthRepository: MemberAuthRepository,val cartRepos
     }
     //비밀번호 찾기
     fun passwordInquiry(passwordInquiryDTO: RequestPasswordInquiryDTO):ResponseEntity<ResponseDTO>{
-        val existMember=memberAuthRepository.findByMemberNameAndPhoneNumber(passwordInquiryDTO.id,passwordInquiryDTO.phoneNumber)
+        val existMember=memberAuthRepository.findByIdAndPhoneNumber(passwordInquiryDTO.id,passwordInquiryDTO.phoneNumber)
 
         lateinit var status:HttpStatus
         lateinit var responseDTO: ResponseDTO

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
@@ -85,4 +85,28 @@ class MemberService(val memberAuthRepository: MemberAuthRepository,val cartRepos
         return ResponseMyPageDTO.memberToResponseMyPageDTO(member)
     }
 
+    //마이페이지 정보  수정
+    fun updateMyPageInfo(memberId:Long?,requestUpdateMyPageDTO: RequestUpdateMyPageDTO):ResponseEntity<ResponseDTO>{
+        val existMember=memberAuthRepository.findByMemberId(memberId).get()
+
+        val existInfo=memberAuthRepository.findById(requestUpdateMyPageDTO.id)
+        val canUpdate=!(existInfo.isPresent && existInfo.get().memberId!=memberId)//이미 존재하는 아이디면서 본인 아이디가 아닌 케이스가 아닌 케이스
+
+        lateinit var status:HttpStatus
+        lateinit var responseDTO: ResponseDTO
+
+        when(canUpdate){
+            true->{
+                existMember.updateMember(requestUpdateMyPageDTO)
+                memberAuthRepository.save(existMember)
+                status=HttpStatus.CREATED
+                responseDTO= ResponseDTO(status.value(),"마이페이지 정보가 성공적으로 수정되었습니다.")
+            }
+            false -> {
+                status=HttpStatus.BAD_REQUEST
+                responseDTO=ResponseDTO(status.value(),"이미 사용중인 아이디입니다.")
+            }
+        }
+        return ResponseEntity(responseDTO,status)
+    }
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
@@ -79,5 +79,10 @@ class MemberService(val memberAuthRepository: MemberAuthRepository,val cartRepos
         return ResponseEntity(responseDTO,status)
     }
 
-        //비밀번호 재설정
+    //마이페이지 정보 조회
+    fun getMyPageInfo(memberId: Long?): ResponseMyPageDTO {
+        val member = memberAuthRepository.findByMemberId(memberId).get()
+        return ResponseMyPageDTO.memberToResponseMyPageDTO(member)
+    }
+
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
@@ -5,8 +5,11 @@ import com.lionTF.CShop.domain.member.models.Member
 import com.lionTF.CShop.domain.member.repository.MemberAuthRepository
 import com.lionTF.CShop.domain.shop.models.Cart
 import com.lionTF.CShop.domain.shop.repository.CartRepository
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -14,6 +17,8 @@ import java.util.*
 @Service
 class MemberService(val memberAuthRepository: MemberAuthRepository,val cartRepository: CartRepository) {
 
+    @Autowired
+    private lateinit var passwordEncoder: PasswordEncoder
 
     //회원가입 로직
     fun registerMember(requestSignUpDTO: RequestSignUpDTO):ResponseEntity<ResponseDTO>{
@@ -107,6 +112,36 @@ class MemberService(val memberAuthRepository: MemberAuthRepository,val cartRepos
                 responseDTO=ResponseDTO(status.value(),"이미 사용중인 아이디입니다.")
             }
         }
+        return ResponseEntity(responseDTO,status)
+    }
+
+    fun updatePassword(memberId:Long?,requestUpdatePasswordDTO: RequestUpdatePasswordDTO):ResponseEntity<ResponseDTO>{
+        val existMember=memberAuthRepository.findByMemberId(memberId).get()
+
+        val pastPassword=requestUpdatePasswordDTO.pastPassword
+        val newPassword=requestUpdatePasswordDTO.newPassword
+
+        val isMatchExistPassword = passwordEncoder.matches(pastPassword,existMember.password)
+        val isPastSameNewPassword= pastPassword==newPassword
+
+        val canUpdate=isMatchExistPassword&&!isPastSameNewPassword
+
+        lateinit var status:HttpStatus
+        lateinit var responseDTO: ResponseDTO
+
+        when(canUpdate){
+            true->{
+                existMember.password=passwordEncoder.encode(newPassword)
+                memberAuthRepository.save(existMember)
+                status=HttpStatus.CREATED
+                responseDTO= ResponseDTO(status.value(),"비밀번호가 성공적으로 수정되었습니다.")
+            }
+            false->{
+                status=HttpStatus.UNAUTHORIZED
+                responseDTO=ResponseDTO(status.value(),"비밀번호 변경이 불가능합니다. 기존 비밀번호와 새 비밀번호을 확인해주세요.")
+            }
+        }
+
         return ResponseEntity(responseDTO,status)
     }
 }

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MemberTests.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MemberTests.kt
@@ -169,7 +169,7 @@ class MemberTests{
     @DisplayName("passwordInquiry Success Test")
     fun passwordInquirySuccessTest(){
         val requestPasswordInquiryDTO= RequestPasswordInquiryDTO(
-            "사용자",
+            "test",
             "01012341234"
         )
 
@@ -202,7 +202,7 @@ class MemberTests{
     @DisplayName("passwordInquiry Fail when wrong phoneNumber Test")
     fun passwordInquiryWhenWrongPhoneNumber(){
         val requestPasswordInquiryDTO= RequestPasswordInquiryDTO(
-            "사용자",
+            "test",
             "01011111111"
         )
 

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MemberTests.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MemberTests.kt
@@ -18,9 +18,15 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
 
 /**
  * 목표: 로그인 성공, 실패 테스트, 회원가입 성공, 실패 테스트
@@ -212,6 +218,15 @@ class MemberTests{
         //then : status code
         assertThat(passwordInquiryResult.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
         assertThat(passwordInquiryResult.body!!.status).isEqualTo(HttpStatus.UNAUTHORIZED.value())
+    }
+
+    @Test
+    @DisplayName("Logout Test")
+    @WithMockCustomUser
+    fun logoutPassword(){
+        mockMvc.perform(post("/members/logout")
+            .with(csrf()))
+            .andExpect(unauthenticated())
     }
 
 }

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MyPageTests.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MyPageTests.kt
@@ -1,0 +1,43 @@
+package com.lionTF.CShop.domain.member.security
+
+import com.lionTF.CShop.domain.member.models.Member
+import com.lionTF.CShop.domain.member.repository.MemberAuthRepository
+import com.lionTF.CShop.domain.member.service.MemberService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/*
+    테스트 동작 방식
+    @WithMockCustomUser
+    - 팩토리 메서드를 통해 custom Autentication을 생성하고 Security context에 넣어주는 작업해주는 어노테이션
+    - 로그인 인증이 필요한 API를 테스트할 때 사용한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class MyPageTests {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+
+    //마이페이지 정보 조회 테스트코드
+    @Test
+    @DisplayName("MyPage Success Test")
+    @WithMockCustomUser
+    fun getMyPageInfoTest(){
+        mockMvc.perform(get("/members")).andExpect(status().isOk()).andDo { println() }
+    }
+}
+
+
+
+
+
+

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MyPageTests.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MyPageTests.kt
@@ -1,16 +1,20 @@
 package com.lionTF.CShop.domain.member.security
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.lionTF.CShop.domain.member.controller.dto.RequestUpdateMyPageDTO
 import com.lionTF.CShop.domain.member.models.Member
+import com.lionTF.CShop.domain.member.models.MemberRole
 import com.lionTF.CShop.domain.member.repository.MemberAuthRepository
-import com.lionTF.CShop.domain.member.service.MemberService
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 /*
@@ -24,8 +28,16 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class MyPageTests {
 
     @Autowired
+    private lateinit var repository: MemberAuthRepository
+
+    @Autowired
+    private lateinit var passwordEncoder: PasswordEncoder
+
+    @Autowired
     private lateinit var mockMvc: MockMvc
 
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
 
     //마이페이지 정보 조회 테스트코드
     @Test
@@ -33,6 +45,54 @@ class MyPageTests {
     @WithMockCustomUser
     fun getMyPageInfoTest(){
         mockMvc.perform(get("/members")).andExpect(status().isOk()).andDo { println() }
+    }
+
+    @Test
+    @DisplayName("MyPage Update Success Test")
+    @WithMockCustomUser
+    fun updateMyPageInfoSuccessTest(){
+        val requestBody=RequestUpdateMyPageDTO(
+            "test",
+            address = "서울시 동작구 상도동 XX빌딩 103호")
+        val content: String = objectMapper.writeValueAsString(requestBody)
+        println(content)
+        mockMvc.perform(
+            put("/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andDo { println() }
+            .andExpect(status().isCreated)
+    }
+
+    @Test
+    @DisplayName("MyPage Update Failed Test")
+    @WithMockCustomUser
+    fun updateMyPageInfoFailTest(){
+        insertUser()
+        val requestBody=RequestUpdateMyPageDTO(
+            "existUser",
+            address = "서울시 동작구 상도동 XX빌딩 103호")
+
+        val content: String = objectMapper.writeValueAsString(requestBody)
+        println(content)
+        mockMvc.perform(
+            put("/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andDo { println() }
+            .andExpect(status().isBadRequest)
+    }
+
+    fun insertUser(){
+        val member: Member = Member(
+            id = "existUser",
+            password= passwordEncoder.encode("tempPW"),
+            phoneNumber = "01012341234",
+            memberName = "사용자",
+            address = "서울시 동작구 상도동 XX빌딩 103호"
+        )
+        member.role=MemberRole.MEMBER
+        repository.save(member)
     }
 }
 

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MyPageTests.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MyPageTests.kt
@@ -2,6 +2,7 @@ package com.lionTF.CShop.domain.member.security
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.lionTF.CShop.domain.member.controller.dto.RequestUpdateMyPageDTO
+import com.lionTF.CShop.domain.member.controller.dto.RequestUpdatePasswordDTO
 import com.lionTF.CShop.domain.member.models.Member
 import com.lionTF.CShop.domain.member.models.MemberRole
 import com.lionTF.CShop.domain.member.repository.MemberAuthRepository
@@ -55,7 +56,6 @@ class MyPageTests {
             "test",
             address = "서울시 동작구 상도동 XX빌딩 103호")
         val content: String = objectMapper.writeValueAsString(requestBody)
-        println(content)
         mockMvc.perform(
             put("/members")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -74,13 +74,56 @@ class MyPageTests {
             address = "서울시 동작구 상도동 XX빌딩 103호")
 
         val content: String = objectMapper.writeValueAsString(requestBody)
-        println(content)
         mockMvc.perform(
             put("/members")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content))
             .andDo { println() }
             .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("MyPage Password Update Success Test")
+    @WithMockCustomUser
+    fun updatePasswordSuccessTest(){
+        val requestBody=RequestUpdatePasswordDTO("test123","1234")
+
+        val content: String = objectMapper.writeValueAsString(requestBody)
+        mockMvc.perform(
+            put("/members/password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andDo { println() }
+            .andExpect(status().isCreated)
+    }
+    @Test
+    @DisplayName("MyPage Password Update Failed when wrong Password Test")
+    @WithMockCustomUser
+    fun updatePasswordFailWhenWrongPasswordTest(){
+        val requestBody=RequestUpdatePasswordDTO("wrongPassword","1234")
+
+        val content: String = objectMapper.writeValueAsString(requestBody)
+        mockMvc.perform(
+            put("/members/password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andDo { println() }
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("MyPage Password Update Failed Test")
+    @WithMockCustomUser
+    fun updatePasswordFailWhenSamePasswordTest(){
+        val requestBody=RequestUpdatePasswordDTO("test123","test123")
+
+        val content: String = objectMapper.writeValueAsString(requestBody)
+        mockMvc.perform(
+            put("/members/password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andDo { println() }
+            .andExpect(status().isUnauthorized)
     }
 
     fun insertUser(){

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/WithMockCustomUser.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/WithMockCustomUser.kt
@@ -1,0 +1,10 @@
+package com.lionTF.CShop.domain.member.security
+
+import org.springframework.security.test.context.support.WithSecurityContext
+
+
+
+
+@Retention(value = AnnotationRetention.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory::class)
+annotation class WithMockCustomUser()

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/WithMockCustomUserSecurityContextFactory.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/WithMockCustomUserSecurityContextFactory.kt
@@ -1,0 +1,44 @@
+package com.lionTF.CShop.domain.member.security
+
+import com.lionTF.CShop.domain.member.controller.dto.AuthMemberDTO
+import com.lionTF.CShop.domain.member.models.Member
+import com.lionTF.CShop.domain.member.models.MemberRole
+import com.lionTF.CShop.domain.member.repository.MemberAuthRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+
+
+class WithMockCustomUserSecurityContextFactory : WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Autowired
+    lateinit var memberAuthRepository: MemberAuthRepository
+
+    @Autowired
+    private lateinit var passwordEncoder: PasswordEncoder
+
+
+    override fun createSecurityContext(customUser: WithMockCustomUser): SecurityContext {
+        val context = SecurityContextHolder.createEmptyContext()
+        val member: Member = Member(
+            id = "test",
+            password= passwordEncoder.encode("test123"),
+            phoneNumber = "01012341234",
+            memberName = "사용자",
+            address = "서울시 동작구 상도동 XX빌딩 103호"
+        )
+        member.role= MemberRole.MEMBER
+        memberAuthRepository.save(member)
+
+        val principal =AuthMemberDTO.memberToAuthMemberDTO(member)
+        val auth: Authentication =
+            UsernamePasswordAuthenticationToken(principal, principal.password, principal.authorities)
+
+        context.authentication = auth
+        return context
+    }
+}


### PR DESCRIPTION
구현 목록
---
1. 마이페이지 정보조회
2. 마이페이지 정보 수정
3. 비밀번호 변경
4. 로그아웃
5. 각각의 테스트코드
6. 비밀번호 찾기 방식 수정
    - 기획에는 id와 전화번호로 비밀번호 찾기를 수행했는데 저번 커밋때 구현을 이름과 전화번호로 찾는 방식으로 잘못 구현하여 수정했습니다.
 

고려사항
---
- 비밀번호 재설정은 임시비밀번호를 발송해주는 방식으로 변경함에 따라 전화번호 인증 구현 후 구현 예정입니다.
- 로그인 세션 사용방식과 withMockUser 어노테이션 사용방식은 이슈로 올리겠습니다.


