### PR TITLE
Feature/email : Feat,Edit - email 컬럼추가 및 이메일을 통한 임시 비밀번호 발급 구현

### DIFF
--- a/C-Shop/build.gradle.kts
+++ b/C-Shop/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
 
 	// thymeleaf 추가
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+
+	//email
+	implementation ("org.springframework.boot:spring-boot-starter-mail")
 }
 
 //querydsl

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/MemberController.kt
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.*
 
 
 @Controller
-//@RequestMapping("/members")
 class MemberController(private val memberService: MemberService) {
 
     //로그인 관련

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MailDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/MailDTO.kt
@@ -1,0 +1,26 @@
+package com.lionTF.CShop.domain.member.controller.dto
+
+data class MailDTO (var toAddress:String,
+                   var title:String,
+                   var message:String,
+                   val fromAddress:String){
+
+    companion object{
+        fun toPasswordInquiryMailDTO(id:String,toAddress: String,tempPw:String):MailDTO{
+            val title = "$id 님 임시 비밀번호 안내 이메일 입니다."
+            val message = """
+            안녕하세요. $id 님 임시 비밀번호 안내 메일입니다.
+            회원님의 임시 비밀번호는 아래와 같습니다. 로그인 후 반드시 비밀번호를 변경해주시길 바랍니다. 
+            임시 비밀번호 : $tempPw
+            """.trimIndent()
+            val fromAddress = "cshop1234@naver.com"           //TODO("yml파일로 따로빼서 사용하게하기")
+
+            return MailDTO(
+                toAddress,
+                title,
+                message,
+                fromAddress
+            )
+        }
+    }
+}

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/RequestPasswordInquiryDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/RequestPasswordInquiryDTO.kt
@@ -1,6 +1,6 @@
 package com.lionTF.CShop.domain.member.controller.dto
 
-data class RequestPasswordInquiryDTO (var id:String,var phoneNumber:String){
+data class RequestPasswordInquiryDTO (var id:String,var email:String){
     companion object{
         fun toFormDTO():RequestPasswordInquiryDTO{
             return RequestPasswordInquiryDTO("","")

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/RequestSignUpDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/controller/dto/RequestSignUpDTO.kt
@@ -9,6 +9,7 @@ data class RequestSignUpDTO(var id:String="",
                             var phoneNumber:String="",
                             var memberName:String="",
                             var address:String="",
+                            var email:String="",
                             var detailAddress:String=""){
 
 

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/models/Member.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/models/Member.kt
@@ -29,6 +29,7 @@ class Member(
     var phoneNumber: String = "",
     var memberName: String = "",
     var address: String = "",
+    var email:String="",
     var detailAddress:String="",
     var memberStatus: Boolean = true,
 
@@ -43,6 +44,7 @@ class Member(
                 phoneNumber=requestSignUpDTO.phoneNumber,
                 memberName=requestSignUpDTO.memberName,
                 address=requestSignUpDTO.address,
+                email=requestSignUpDTO.email,
                 detailAddress=requestSignUpDTO.detailAddress,
                 role = MemberRole.MEMBER
             )

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
@@ -10,7 +10,7 @@ interface MemberAuthRepository:JpaRepository<Member,Long> {
 
     @Query("select m from Member m where m.id = :id")
     fun findById(@Param("id")id:String):Optional<Member>
-    fun findByIdAndPhoneNumber(id:String,phoneNumber: String):Optional<Member>
+    fun findByIdAndEmail(id:String,email: String):Optional<Member>
     fun findByMemberNameAndPhoneNumber(memberName:String,phoneNumber:String):Optional<Member>
     fun findByMemberId(memberId:Long?):Optional<Member>
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/repository/MemberAuthRepository.kt
@@ -2,6 +2,7 @@ package com.lionTF.CShop.domain.member.repository
 
 import com.lionTF.CShop.domain.member.models.Member
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.Optional
@@ -10,7 +11,11 @@ interface MemberAuthRepository:JpaRepository<Member,Long> {
 
     @Query("select m from Member m where m.id = :id")
     fun findById(@Param("id")id:String):Optional<Member>
+
     fun findByIdAndEmail(id:String,email: String):Optional<Member>
+
     fun findByMemberNameAndPhoneNumber(memberName:String,phoneNumber:String):Optional<Member>
+
     fun findByMemberId(memberId:Long?):Optional<Member>
+
 }

--- a/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/CShop/domain/member/service/MemberService.kt
@@ -53,7 +53,7 @@ class MemberService(val memberAuthRepository: MemberAuthRepository,val cartRepos
     }
     //비밀번호 찾기
     fun passwordInquiry(passwordInquiryDTO: RequestPasswordInquiryDTO):ResponseDTO{
-        val existMember=memberAuthRepository.findByIdAndPhoneNumber(passwordInquiryDTO.id,passwordInquiryDTO.phoneNumber)
+        val existMember=memberAuthRepository.findByIdAndEmail(passwordInquiryDTO.id,passwordInquiryDTO.email)
 
         return if(existMember.isPresent){
             ResponseDTO.toSuccessPasswordInquiryResponseDTO()

--- a/C-Shop/src/main/resources/templates/members/forget-id.html
+++ b/C-Shop/src/main/resources/templates/members/forget-id.html
@@ -22,7 +22,7 @@
             <img src="images/logo.png" alt="">
           </a>
           <h4 class="text-center mt-30">아이디 찾기</h4>
-          <form class="text-left clearfix" th:action="@{/members/idInquiry}" th:object="${requestIdInquiryDTO}" th:method="post">
+          <form class="text-left clearfix" th:action="@{/members/id-inquiry}" th:object="${requestIdInquiryDTO}" th:method="post">
             <div class="form-group">
               <input type="text" class="form-control login-input" id="name" th:field="*{memberName}" placeholder="이름을 입력해주세요">
             </div>

--- a/C-Shop/src/main/resources/templates/members/forget-password.html
+++ b/C-Shop/src/main/resources/templates/members/forget-password.html
@@ -22,7 +22,7 @@
             </div>
             <div class="form-group">
               <ul class="list-inline">
-                <li><input type="tel" id="tel" class="form-control form-tel login-input"  th:field="*{phoneNumber}" placeholder="전화번호를 입력해주세요"></li>
+                <li><input type="email" id="tel" class="form-control form-tel login-input"  th:field="*{email}" placeholder="이메일을 입력해주세요"></li>
                   <li><button class="btn btn-small  btn-xsmall btn-round text-center">인증번호 전송</button></li>
                     <li><button class="btn btn-small btn-xsmall btn-round text-center">재발송</button></li>
                   </ul>

--- a/C-Shop/src/main/resources/templates/members/forget-password.html
+++ b/C-Shop/src/main/resources/templates/members/forget-password.html
@@ -15,22 +15,14 @@
             <img src="images/logo.png" alt="">
           </a>
           <h4 class="text-center mt-30">비밀번호 찾기</h4>
-          <form class="text-left clearfix" th:action="@{/members/passwordInquiry}" th:object="${requestPasswordInquiryDTO}" th:method="post" >
+          <form class="text-left clearfix" th:action="@{/members/password-inquiry}" th:object="${requestPasswordInquiryDTO}" th:method="post" >
 <!--            onsubmit="return checkForgetPw()"-->
             <div class="form-group">
               <input type="text" class="form-control login-input" id="user-id"  th:field="*{id}" placeholder="아이디를 입력해주세요">
             </div>
             <div class="form-group">
-              <ul class="list-inline">
-                <li><input type="email" id="tel" class="form-control form-tel login-input"  th:field="*{email}" placeholder="이메일을 입력해주세요"></li>
-                  <li><button class="btn btn-small  btn-xsmall btn-round text-center">인증번호 전송</button></li>
-                    <li><button class="btn btn-small btn-xsmall btn-round text-center">재발송</button></li>
-                  </ul>
+                <input type="email" id="tel" class="form-control form-tel login-input"  th:field="*{email}" placeholder="이메일을 입력해주세요"></li>
               </div>
-
-            <div class="form-group">
-              <input type="password" class="form-control login-input" id="auth-num" placeholder="인증번호를 입력해주세요">
-            </div>
             <div class="text-center">
               <button type="submit" class="btn btn-small  text-center btn-round btn-login-page btn-subcolor">확인</button>
             </div>

--- a/C-Shop/src/main/resources/templates/members/signup.html
+++ b/C-Shop/src/main/resources/templates/members/signup.html
@@ -55,10 +55,8 @@
             <input type="text" class="form-control signin-input"  id="sub-addr"  th:field="*{detailAddress}" placeholder="상세 주소를 입력해주세요.">
           </div>
             <div class="form-group ml-30">
-              <div class="login-age-check-group">
-                <label class="label-vertical-align">나이</label>
-                <button type="button" class="btn btn-main btn-round text-center ml-10 btn-login-page">본인인증</button>
-              </div>
+                <label>이메일</label>
+                <input type="email" class="form-control signin-input" id="email" th:field="*{email}" placeholder="이메일을 입력해주세요.">
             </div>
           </div>
           <div class="text-center">

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MemberTests.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/MemberTests.kt
@@ -59,6 +59,7 @@ class MemberTests{
             phoneNumber = "01012341234",
             memberName = "사용자",
             address = "서울시 동작구 상도동",
+            email="test@naver.com",
             detailAddress = "XX빌딩 103호"
         )
         member.role=MemberRole.MEMBER
@@ -88,6 +89,7 @@ class MemberTests{
             password = "test123",
             phoneNumber = "01012341234",
             memberName = "사용자",
+            email="test@naver.com",
             address = "서울시 동작구 상도동",
             detailAddress = "XX빌딩 103호"
         )
@@ -107,12 +109,12 @@ class MemberTests{
             password = "test123",
             phoneNumber = "01012341234",
             memberName = "사용자",
+            email="test@naver.com",
             address = "서울시 동작구 상도동",
             detailAddress = "XX빌딩 103호"
         )
 
         //when : 같은 정보갖는 회원 두번 삽입
-        memberService.registerMember(requestSignUpDTO)
         val signUpResult=memberService.registerMember(requestSignUpDTO)
         //then
         assertThat(signUpResult.status).isEqualTo(ResponseDTO.toFailedSignUpResponseDTO().status)
@@ -172,7 +174,7 @@ class MemberTests{
     fun passwordInquirySuccessTest(){
         val requestPasswordInquiryDTO= RequestPasswordInquiryDTO(
             "test",
-            "01012341234"
+            "test@naver.com"
         )
 
 
@@ -188,7 +190,7 @@ class MemberTests{
     fun passwordInquiryWhenWrongMemberName(){
         val requestPasswordInquiryDTO= RequestPasswordInquiryDTO(
             "없는사용자",
-            "01012341234"
+            "test@naver.com"
         )
 
         //when : 존재하지 않는 사  용자 정보를 줌
@@ -203,7 +205,7 @@ class MemberTests{
     fun passwordInquiryWhenWrongPhoneNumber(){
         val requestPasswordInquiryDTO= RequestPasswordInquiryDTO(
             "test",
-            "01011111111"
+            "noUser@naver.com"
         )
 
         //when : 사용자는 존재하지만 전화번호 잘못된 경우

--- a/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/WithMockCustomUserSecurityContextFactory.kt
+++ b/C-Shop/src/test/kotlin/com/lionTF/CShop/domain/member/security/WithMockCustomUserSecurityContextFactory.kt
@@ -29,6 +29,7 @@ class WithMockCustomUserSecurityContextFactory : WithSecurityContextFactory<With
             password= passwordEncoder.encode("test123"),
             phoneNumber = "01012341234",
             memberName = "사용자",
+            email = "test@naver.com",
             address = "서울시 동작구 상도동",
             detailAddress = "XX빌딩 103호"
         )


### PR DESCRIPTION
구현 사항
---
1. email 컬럼 member와 DTO에 추가
2. 이메일을 이용한 임시 비밀번호 발급 구현

참고 사항
---
1. 가입시 필요한 이메일인증은 인증번호 저장이 요구됩니다. redis에 저장하는 방식을 채택해볼 예정입니다.
2. 따라서, redis를 이용한 session 처리 적용과 함께 구현할 예정입니다.
3. 이메일인증이 작동하기 위해서는 yml 파일에 Credentials한 정보가 필요합니다. 따라서 application.yml 일부분을 제가 따로 보내드리겠습니다.