### PR TITLE
페이지에 들어가는 아이템 수 변경

### DIFF
--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/PageRequestDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/PageRequestDTO.kt
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Sort
 
 data class PageRequestDTO(
     var page: Int = 1,
-    var size: Int = 2,
+    var size: Int = 9,
     var sort: String? = null,
     var category: Category? = null,
     var keyword: String? = null

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/PageResultDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/PageResultDTO.kt
@@ -52,7 +52,6 @@ data class PageResultDTO<DTO,EN> (var data:List<DTO>?=null,
                                   var prev:Boolean?=null,
                                   var next:Boolean?=null,
                                   var pageList:MutableList<Int>? = null,
-                                  //var status:Int?= HttpStatus.OK.value()
 ){//DTO=dto 타입, EN=entity 타입
 constructor(result: Page<EN>,fn:Function<EN,DTO>):this(){
     data=result.map(fn).toList()
@@ -64,12 +63,9 @@ constructor(result: Page<EN>,fn:Function<EN,DTO>):this(){
     private fun makePageList(pageable:Pageable){
         this.page=pageable.pageNumber+1
         this.size=pageable.pageSize
-        println(page)
 
         val tempEnd:Int=((ceil(page/10.0))*10).toInt()
-        println(tempEnd)
         start=tempEnd-9
-        println(start)
         prev=start>1
 
         next=totalPage!!>tempEnd


### PR DESCRIPTION
1. 한 페이지에 들어가는 상품 개수 2개->9개로 수정했습니다.