### PR TITLE
Shop kyungjun

### DIFF
--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/AddCartCocktailItemDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/AddCartCocktailItemDTO.kt
@@ -78,6 +78,14 @@ data class AddCartCocktailItemResultDTO(
             )
         }
 
+        fun setAllZeroFailAddCartCocktailItemResultDTO() : AddCartCocktailItemResultDTO{
+            return AddCartCocktailItemResultDTO(
+                status = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                message = "적어도 하나 이상의 상품을 담으셔야 합니다.",
+                href = "/items"
+            )
+        }
+
     }
 }
 

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/OrderItemDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/OrderItemDTO.kt
@@ -1,11 +1,18 @@
 package com.lionTF.cshop.domain.shop.controller.dto
 
 import com.lionTF.cshop.domain.admin.models.Item
+import com.lionTF.cshop.domain.shop.models.OrderItem
 import com.lionTF.cshop.domain.shop.models.Orders
 
 data class OrderItemDTO(
     var orders: Orders,
     var item: Item,
     var amount: Int,
-)
+){
+    companion object{
+        fun fromOrderRequestInfo(orders: Orders, item: Item, amount: Int) : OrderItemDTO{
+            return OrderItemDTO(orders,item,amount)
+        }
+    }
+}
 

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/RequestOrderDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/controller/dto/RequestOrderDTO.kt
@@ -87,6 +87,14 @@ data class RequestOrderResultDTO(
                 href = "items"
             )
         }
+
+        fun setRequestOrderAllZeroFailResultDTO() : RequestOrderResultDTO{
+            return RequestOrderResultDTO(
+                status = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                message = "적어도 한 개 이상의 상품은 주문하셔야 합니다.",
+                href = "items"
+            )
+        }
     }
 }
 

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/service/CartItemServiceImpl.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/service/CartItemServiceImpl.kt
@@ -48,18 +48,20 @@ class CartItemServiceImpl(
         val cart = cartRepository.getCart(addCartCocktailItemDTO.memberId)
         val cartItemDTOList: MutableList<CartItemDTO> = mutableListOf()
         val items = addCartCocktailItemDTO.items
-
+        var zeroAmountCount = 0
         items.map{
             val itemInfo = itemRepository.getReferenceById(it.itemId)
 
-            if(it.amount <= 0){
+            if(it.amount == 0) zeroAmountCount++
+
+            if(it.amount < 0){
                 return AddCartCocktailItemResultDTO.setNotPositiveError()
             }
 
             if(itemInfo.amount > it.amount){
 
                 if(itemInfo.itemStatus){
-                    cartItemDTOList.add(CartItemDTO(itemInfo,cart,it.amount))
+                    if(it.amount > 0)  cartItemDTOList.add(CartItemDTO(itemInfo,cart,it.amount))
                 }else{
                     return AddCartCocktailItemResultDTO.setStatusFailAddCartCocktailItemResultDTO()
                 }
@@ -67,6 +69,8 @@ class CartItemServiceImpl(
                 return AddCartCocktailItemResultDTO.setAmountFailAddCartCocktailItemResultDTO()
             }
         }
+
+        if(zeroAmountCount==items.size) return AddCartCocktailItemResultDTO.setAllZeroFailAddCartCocktailItemResultDTO()
 
         for(cartItemDTO in cartItemDTOList){
             cartItemRepository.save(CartItem.fromCartItemDTO(cartItemDTO))

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/service/OrderServiceImpl.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/service/OrderServiceImpl.kt
@@ -66,11 +66,7 @@ class OrderServiceImpl(
 
                 orderItemRepository.save(
                     OrderItem.fromOrderItemDTO(
-                        OrderItemDTO(
-                            orders,
-                            item,
-                            info.amount
-                        )
+                        OrderItemDTO.fromOrderRequestInfo(orders, item, info.amount)
                     )
                 )
             }

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/service/OrderServiceImpl.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/shop/service/OrderServiceImpl.kt
@@ -26,13 +26,14 @@ class OrderServiceImpl(
     //상품 주문 메소드
     @Transactional
     override fun requestOrder(requestOrderDTO: RequestOrderDTO) : RequestOrderResultDTO {
-
+        var zeroAmountCount = 0
          requestOrderDTO.orderItems.map{
             val requestAmount = it.amount
             val existAmount = itemRepository.getReferenceById(it.itemId).amount
 
+             if(requestAmount == 0) zeroAmountCount++
 
-            if(requestAmount <= 0){
+            if(requestAmount < 0){
                 return RequestOrderResultDTO.setNotPositiveError()
             }
 
@@ -42,6 +43,7 @@ class OrderServiceImpl(
             else return RequestOrderResultDTO.setRequestOrderStatusFailResultDTO()
         }
 
+        if(zeroAmountCount == requestOrderDTO.orderItems.size) return RequestOrderResultDTO.setRequestOrderAllZeroFailResultDTO()
 
         val member = requestOrderDTO.memberId?.let { memberRepository.getReferenceById(it) }
 
@@ -58,18 +60,20 @@ class OrderServiceImpl(
 
         for(info in requestOrderDTO.orderItems){
             val item = itemRepository.getReferenceById(info.itemId)
-            item.amount -= info.amount
-            itemRepository.save(item)
+            if(info.amount > 0){
+                item.amount -= info.amount
+                itemRepository.save(item)
 
-            orderItemRepository.save(
-                OrderItem.fromOrderItemDTO(
-                    OrderItemDTO(
-                        orders,
-                        item,
-                        info.amount
+                orderItemRepository.save(
+                    OrderItem.fromOrderItemDTO(
+                        OrderItemDTO(
+                            orders,
+                            item,
+                            info.amount
+                        )
                     )
                 )
-            )
+            }
         }
         return RequestOrderResultDTO.setRequestOrderSuccessResultDTO()
     }

--- a/C-Shop/src/main/resources/templates/global/NonAlcoholHeader.html
+++ b/C-Shop/src/main/resources/templates/global/NonAlcoholHeader.html
@@ -65,7 +65,7 @@
                       class="tf-ion-ios-search-strong"></i> Search</a>
               <ul class="dropdown-menu search-dropdown">
                 <li>
-                  <form th:action="@{/items/search/NONALCOHOL}" th:method="get"><input name="keyword" type="search" class="form-control" placeholder="주류 검색..."></form>
+                  <form th:action="@{/items/search/NONALCOHOL}" th:method="get"><input name="keyword" type="search" class="form-control" placeholder="비주류 검색..."></form>
                 </li>
               </ul>
             </li><!-- / Search -->

--- a/C-Shop/src/main/resources/templates/shop/singleCocktail.html
+++ b/C-Shop/src/main/resources/templates/shop/singleCocktail.html
@@ -37,11 +37,10 @@
 
                     <th:block th:each="items, i : *{orderItems}">
                     <div class="product-quantity">
-                        <span><div th:text="${items.itemName}"></div></span>
-
-                        <input th:type="hidden" th:field="*{orderItems[__${i.index}__].itemName}">
+                        <span><a th:href="'/items/'+${items.itemId}"><div th:text="${items.itemName}"></div></a></span>
 
                         <input th:type="hidden" th:field="*{orderItems[__${i.index}__].itemId}">
+                        <input th:type="hidden" th:field="*{orderItems[__${i.index}__].itemName}">
                         <span>가격<input type="text" th:field="*{orderItems[__${i.index}__].price}" readonly></span>
 
                         <span></span>


### PR DESCRIPTION
1. 칵테일 상세조회 화면
- 구성 상품 이름에 링크를 걸어두어 누르면 해당 상품의 상세 조회 하면으로 이동하기 추가
- 주문, 장바구니 추가 시 (구성 상품 중 하나라도 0개이면 에러 -> 모두 0개여야 에러가 나도록 수정)
- 주문 시 발생했던 에러 해결

2. NonAlcolhol header파일 수정
- 검색 부분 placeholder가 주류로 되어 있어서 비주류로 수정