### PR TITLE
Fix: 주류, 칵테일, 비주류 조회시 화면 깨지는 현상 해결 및 회원 삭제 시 주문 목록에도 보이게 수정했습니다.

### DIFF
--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/admin/repository/custom/AdminOrderRepositoryImpl.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/admin/repository/custom/AdminOrderRepositoryImpl.kt
@@ -75,7 +75,7 @@ class AdminOrderRepositoryImpl(
             .where(
                 isEqualMemberId(),
                 booleanBuilder,
-                isExistedMember()
+//                isExistedMember()
             )
             .orderBy(orderItem.createdAt.desc())
             .offset(pageable.offset)
@@ -113,7 +113,7 @@ class AdminOrderRepositoryImpl(
             .where(
                 booleanBuilder,
                 isEqualMemberId(),
-                isExistedMember()
+//                isExistedMember()
             )
     }
 
@@ -131,5 +131,5 @@ class AdminOrderRepositoryImpl(
 
     private fun isEqualMemberId() = member.memberId.eq(orders.member.memberId)
 
-    private fun isExistedMember() = member.memberStatus.eq(true)
+//    private fun isExistedMember() = member.memberStatus.eq(true)
 }

--- a/C-Shop/src/main/resources/templates/shop/shopAlcohol.html
+++ b/C-Shop/src/main/resources/templates/shop/shopAlcohol.html
@@ -31,7 +31,8 @@
                             </div>
                         </div>
                         <div class="product-content">
-                            <h4><a th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} > 20" th:href="'/items/'+${items.itemId}">[[${#strings.append(#strings.substring(items.itemName,0,20),'...')}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} < 20" th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
                             <p class="price">가격:[[${items.price}]]원</p>
                             <p class="price">도수:[[${items.degree}]]</p>
                         </div>

--- a/C-Shop/src/main/resources/templates/shop/shopCocktail.html
+++ b/C-Shop/src/main/resources/templates/shop/shopCocktail.html
@@ -31,7 +31,8 @@
                         </div>
                     </div>
                     <div class="product-content">
-                        <h4><a th:href="'/items/cocktails/'+${items.cocktailId}">[[${items.cocktailName}]]</a></h4>
+                        <h4><a th:if="${#strings.length(items.cocktailName)} > 20" th:href="'/items/cocktails/'+${items.cocktailId}">[[${#strings.append(#strings.substring(items.cocktailName,0,20),'...')}]]</a></h4>
+                        <h4><a th:if="${#strings.length(items.cocktailName)} < 20" th:href="'/items/cocktails/'+${items.cocktailId}">[[${items.cocktailName}]]</a></h4>
                     </div>
                 </div>
             </div>

--- a/C-Shop/src/main/resources/templates/shop/shopNonAlcohol.html
+++ b/C-Shop/src/main/resources/templates/shop/shopNonAlcohol.html
@@ -31,7 +31,8 @@
                             </div>
                         </div>
                         <div class="product-content">
-                            <h4><a th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} > 20" th:href="'/items/'+${items.itemId}">[[${#strings.append(#strings.substring(items.itemName,0,20),'...')}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} < 20" th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
                             <p class="price">가격:[[${items.price}]]원</p>
                             <p class="price">도수:[[${items.degree}]]</p>
                         </div>

--- a/C-Shop/src/main/resources/templates/shop/shopSearchAlcohol.html
+++ b/C-Shop/src/main/resources/templates/shop/shopSearchAlcohol.html
@@ -31,7 +31,8 @@
                             </div>
                         </div>
                         <div class="product-content">
-                            <h4><a th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} > 20" th:href="'/items/'+${items.itemId}">[[${#strings.append(#strings.substring(items.itemName,0,20),'...')}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} < 20" th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
                             <p class="price">가격:[[${items.price}]]원</p>
                             <p class="price">도수:[[${items.degree}]]</p>
                         </div>

--- a/C-Shop/src/main/resources/templates/shop/shopSearchCocktail.html
+++ b/C-Shop/src/main/resources/templates/shop/shopSearchCocktail.html
@@ -31,7 +31,8 @@
                             </div>
                         </div>
                         <div class="product-content">
-                            <h4><a th:href="'/items/cocktails/'+${items.cocktailId}">[[${items.cocktailName}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.cocktailName)} > 20" th:href="'/items/cocktails/'+${items.cocktailId}">[[${#strings.append(#strings.substring(items.cocktailName,0,20),'...')}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.cocktailName)} < 20" th:href="'/items/cocktails/'+${items.cocktailId}">[[${items.cocktailName}]]</a></h4>
                         </div>
                     </div>
                 </div>

--- a/C-Shop/src/main/resources/templates/shop/shopSearchNonAlcohol.html
+++ b/C-Shop/src/main/resources/templates/shop/shopSearchNonAlcohol.html
@@ -31,7 +31,8 @@
                             </div>
                         </div>
                         <div class="product-content">
-                            <h4><a th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} > 20" th:href="'/items/'+${items.itemId}">[[${#strings.append(#strings.substring(items.itemName,0,20),'...')}]]</a></h4>
+                            <h4><a th:if="${#strings.length(items.itemName)} < 20" th:href="'/items/'+${items.itemId}">[[${items.itemName}]]</a></h4>
                             <p class="price">가격:[[${items.price}]]원</p>
                             <p class="price">도수:[[${items.degree}]]</p>
                         </div>


### PR DESCRIPTION
**이슈 수정 내역**
1. 주류, 칵테일, 비주류 조회시 화면 깨지는 현상 해결 -> 상품명 글자수 길이에 따른 문제로 상품 등록 시에 필수로 상품명을 등록해야 되고 상품명의 길이가 너무 길때에는 글자수 20으로 제한하고 나머지 글자는 '...'처리하여 화면 깨지는 현상 해결했습니다.
2. 회원 삭제 시 주문 목록에도 보이게 수정했습니다.