### PR TITLE
Fix/members : Fix - 백엔드 관련 QA 요청사항 반영

### DIFF
--- a/C-Shop/build.gradle.kts
+++ b/C-Shop/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
 
 	//redis
 	implementation ("org.springframework.boot:spring-boot-starter-data-redis")
-	implementation ("org.springframework.session:spring-session-data-redis:2.7.0")
+	implementation ("org.springframework.session:spring-session-data-redis")
 
 	//oauth
 	implementation ("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/admin/service/AdminMemberServiceImpl.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/admin/service/AdminMemberServiceImpl.kt
@@ -4,12 +4,15 @@ import com.lionTF.cshop.domain.admin.controller.dto.*
 import com.lionTF.cshop.domain.admin.repository.AdminMemberRepository
 import com.lionTF.cshop.domain.admin.service.admininterface.AdminMemberService
 import org.springframework.data.domain.Pageable
+import org.springframework.session.FindByIndexNameSessionRepository
+import org.springframework.session.FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME
 import org.springframework.stereotype.Service
 import javax.transaction.Transactional
 
 @Service
 class AdminMemberServiceImpl(
     private val adminMemberRepository: AdminMemberRepository,
+    private val findByIndexNameSessionRepository: FindByIndexNameSessionRepository<*>,
 ) : AdminMemberService {
 
     @Transactional
@@ -22,6 +25,10 @@ class AdminMemberServiceImpl(
             val member = adminMemberRepository.getReferenceById(memberId)
             member.deleteMember()
 
+            val memberSessions = findByIndexNameSessionRepository.findByIndexNameAndIndexValue(PRINCIPAL_NAME_INDEX_NAME,member.id)
+            memberSessions?.map {
+                findByIndexNameSessionRepository.deleteById(it.key)
+            }
             AdminResponseDTO.toSuccessDeleteMemberResponseDTO()
         }
     }

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/controller/dto/MemberResponseDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/controller/dto/MemberResponseDTO.kt
@@ -15,7 +15,7 @@ data class MemberResponseDTO(
         }
 
         fun toFailedSocialLoginResponseDTO(): MemberResponseDTO {
-            return MemberResponseDTO(HttpStatus.UNAUTHORIZED.value(), "이메일 약관을 동의하지 않았거나 탈퇴한 회원입니다.", "/members/login")
+            return MemberResponseDTO(HttpStatus.UNAUTHORIZED.value(), "이메일 약관을 동의하지 않았거나 가입 기록이 있는 이메일입니다.(탈퇴 회원 포함)", "/members/login")
         }
 
         fun toSuccessSignUpResponseDTO(): MemberResponseDTO {
@@ -23,7 +23,7 @@ data class MemberResponseDTO(
         }
 
         fun toFailedSignUpResponseDTO(): MemberResponseDTO {
-            return MemberResponseDTO(HttpStatus.UNAUTHORIZED.value(), "이미 존재하는 아이디입니다.", "/members/login")
+            return MemberResponseDTO(HttpStatus.UNAUTHORIZED.value(), "가입 기록이 있는 아이디 또는 이메일 입니다. (탈퇴 회원 포함)", "/members/login")
         }
 
         fun toDeletedIdInquiryResponseDTO(): MemberResponseDTO {

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/repository/MemberAuthRepository.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/repository/MemberAuthRepository.kt
@@ -7,6 +7,10 @@ interface MemberAuthRepository : JpaRepository<Member, Long> {
 
     fun findById(id: String): Member?
 
+    fun findByEmail(email: String): Member?
+
+    fun findByIdOrEmail(id: String, email: String): List<Member>?
+
     fun findByIdAndEmail(id: String, email: String): Member?
 
     fun findByMemberNameAndEmail(memberName: String, email: String): Member?

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/service/MemberServiceImpl.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/service/MemberServiceImpl.kt
@@ -27,9 +27,9 @@ class MemberServiceImpl(
         signUpRequestDTO.encoding(passwordEncoder)
 
         val newMember = Member.fromRequestSignUpDTO(signUpRequestDTO)
-        val existMember = memberAuthRepository.findById(newMember.id)
+        val existMembers = memberAuthRepository.findByIdOrEmail(newMember.id, newMember.email)
 
-        return if (existMember != null) {
+        return if (existMembers != null) {
             MemberResponseDTO.toFailedSignUpResponseDTO()
         } else {
             memberAuthRepository.save(newMember)

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/service/OAuth2UserDetailsService.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/domain/member/service/OAuth2UserDetailsService.kt
@@ -29,12 +29,13 @@ class OAuth2UserDetailsService(
         val email = account["email"] as String? ?: throw UsernameNotFoundException("이메일 동의 필요")
         val name = properties["nickname"] as String
 
-        val existMember = memberAuthRepository.findById(email)
+        val existMember = memberAuthRepository.findByEmail(email)
 
         return if (existMember != null) {
-            when (existMember.memberStatus) {
-                true -> AuthMemberDTO.fromMember(existMember)
-                false -> throw UsernameNotFoundException("탈퇴한 회원")
+            when {
+                !existMember.memberStatus -> throw UsernameNotFoundException("탈퇴한 회원")
+                existMember.fromSocial -> AuthMemberDTO.fromMember(existMember)
+                else -> throw UsernameNotFoundException("이미 가입된 이메일입니다.")
             }
         } else {
             val newMember = Member.fromOAuth2User(name, email)

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/global/controller/BasicErrorController.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/global/controller/BasicErrorController.kt
@@ -1,0 +1,28 @@
+package com.lionTF.cshop.global.controller
+
+import com.lionTF.cshop.domain.member.controller.dto.MemberResponseDTO
+import com.lionTF.cshop.global.controller.dto.ErrorMessageDTO
+import org.springframework.boot.web.servlet.error.ErrorController
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import javax.servlet.RequestDispatcher
+import javax.servlet.http.HttpServletRequest
+
+
+@Controller
+class BasicErrorController : ErrorController {
+
+    @GetMapping("/error")
+    fun handleError(model: Model, request: HttpServletRequest): String {
+        val status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)
+
+        if (status != null) {
+            val statusCode = Integer.valueOf(status.toString())
+            model.addAttribute("result", ErrorMessageDTO.toBasicErrorMessageDTO(statusCode))
+        } else {
+            model.addAttribute("result", MemberResponseDTO.toMemberAccessDeniedResponseDTO())
+        }
+        return "global/BasicError"
+    }
+}

--- a/C-Shop/src/main/kotlin/com/lionTF/cshop/global/controller/dto/ErrorMessageDTO.kt
+++ b/C-Shop/src/main/kotlin/com/lionTF/cshop/global/controller/dto/ErrorMessageDTO.kt
@@ -1,0 +1,19 @@
+package com.lionTF.cshop.global.controller.dto
+
+import com.lionTF.cshop.domain.member.controller.dto.MemberResponseDTO
+import org.springframework.http.HttpStatus
+
+data class ErrorMessageDTO(
+    val status: Int,
+    val message: String,
+    var href: String = ""
+) {
+    companion object{
+        fun toBasicErrorMessageDTO(status: Int): MemberResponseDTO {
+            return when (status) {
+                HttpStatus.INTERNAL_SERVER_ERROR.value() -> MemberResponseDTO(status, "서버 에러 입니다.","/items")
+                else -> MemberResponseDTO(status, "잘못된 접근 입니다.", "/items")
+            }
+        }
+    }
+}

--- a/C-Shop/src/main/resources/templates/global/BasicError.html
+++ b/C-Shop/src/main/resources/templates/global/BasicError.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <th:block th:if="${#strings.length(result.message) != 0}">
+    <script>
+      top.alert("[[${result.message}]]");
+    </script>
+  </th:block>
+  <th:block th:if="${#strings.length(result.href) != 0}">
+    <script>
+      top.location.href = '[[${result.href}]]';
+    </script>
+  </th:block>
+</head>
+</html>


### PR DESCRIPTION
수정 사항
---
1. 컨트롤러에 등록되지 않은 url 접근, url parameter를 잘못 입력시 alert창 띄우게 수정 했습니다.
2. admin이 로그인된 상태인 회원 삭제하면 해당 로그인 세션 제거하여 자동 로그아웃 처리했습니다.
3. 기존 가입된 이력이 있는 이메일, 아이디로는 재가입을 못하도록 수정했습니다.

토의 사항
---
1. 현재 소셜로그인, 로컬 로그인 구분없이 중복 이메일이면 가입 못하게 막아놓았는데 이게 맞는지 아님 소셜로그인에 사용된 이메일과 로컬 로그인시 입력한 이메일을 별개로 쳐야하는지 고민이됩니다.